### PR TITLE
Add missing import

### DIFF
--- a/dtwParallel/dtw_functions.py
+++ b/dtwParallel/dtw_functions.py
@@ -8,6 +8,7 @@
 import numpy as np
 from collections import defaultdict
 import pandas as pd
+import warnings
 
 import gower
 from joblib import Parallel, delayed


### PR DESCRIPTION
`itakaru_mask` uses 'warnings' module that is never imported. 

```
def itakura_mask(sz1, sz2, max_slope=2.):
...
    if raise_warning:
        warnings.warn("'itakura_max_slope' constraint is unfeasible "
                      "(ie. leads to no admissible path) for the "
                      "provided time series sizes",
                      RuntimeWarning)
```